### PR TITLE
Use service account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,13 @@ jobs:
           command: |
             kubectl apply -f ./extras/jwt/jwt-secret.yaml
             kubectl apply -f ./kubernetes-manifests
-
+      - run:
+          name: Wait for deployment
+          command: |
+            kubectl wait deployment -n default frontend --for condition=Available=True --timeout=90s
+      - run: 
+          name: Print Frontend URL
+          command: kubectl get service frontend | awk '{print $4}'
 
 workflows:
   main:


### PR DESCRIPTION
### Fixes AwesomeCICD/reference-architecture#19


 working with @nitin4613 , @dvcastillo , @abuch57 to implement service account from cluster to be used by BoA deployment. 