### PR TITLE
set frontend to use https scheme to avoid unecessary redirects

### DIFF
--- a/dev-kubernetes-manifests/frontend.yaml
+++ b/dev-kubernetes-manifests/frontend.yaml
@@ -76,7 +76,7 @@ spec:
         - name: ENABLE_METRICS
           value: "true"
         - name: SCHEME
-          value: "http"
+          value: "https"
          # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
         - name: LOG_LEVEL
           value: "info"


### PR DESCRIPTION
right now ingress gateway forces ssl , but frontend assumes http urls meaning browsers gets a 301 and extra request for every interaction.