### PR TITLE
Breaks python modules into parallel builds via test splitting. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
                 pip install -r requirements.txt
                 #CLI wraps test runner to allow "rerun failed tests only"
                 TEST_FILES=$(circleci tests glob "tests/test_*.py")
-                echo $TEST_FILES | circleci tests run --command="xargs python -m pytest --junit-xml=../../test-reports/report-${SERVICE}.xml -v -p no:warnings" --verbose --split-by=timings
+                echo $TEST_FILES | circleci tests run --command="xargs python -m pytest -o junit_family=legacy --junit-xml=../../test-reports/report-${SERVICE}.xml -v -p no:warnings" --verbose --split-by=timings
                 deactivate
               # return to previously saved path
               popd


### PR DESCRIPTION
Due to multi-module nature of this monolith, we get better performance by isolating each service vs the collection of tests as whole, which would require each node to still install and likely run all classes.

