### PR TITLE
Dev smaller parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     type: enum
     description: where we are deploying, a CERA cluster region
     enum: [ namer, emea, japac]
-    default: emea
+    default: namer
     
 executors:
   with-chrome:


### PR DESCRIPTION
Since python step only uses 25% of CPU and no ram I dropped parallel job to small. 

2x small jobs uses 10 credits/minute

1x large job used now is 20 for single node.


50% the cost, 50% the time, really close to 25% the cost!

*** dropping single node to small would be %25 savings too but not as fast.