### PR TITLE
rename java files and classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,7 @@ workflows:
           region: <<matrix.region>>
           name: Skaffold build & Push [<<matrix.region>>]
       - deploy:
+          serial-group: << pipeline.project.slug >>/deploy-dev-<<matrix.region>>
           matrix:
             parameters:
               region: [emea,namer]
@@ -352,6 +353,7 @@ workflows:
           requires: [ 'Deploy Dev [<<matrix.region>>]' ]
           region: <<matrix.region>>
       - deploy:
+          serial-group: << pipeline.project.slug >>/deploy-production-<<matrix.region>>
           matrix:
             parameters:
               region: [emea,namer]

--- a/demo-assets/README.md
+++ b/demo-assets/README.md
@@ -2,6 +2,14 @@
 
 Just run `./demo-assets/runDemo.py` and follow the prompts!
 
+### Python/Pip issues.
+
+I moved project to `uv` install `uv` and run:
+```
+uv venv
+uv sync
+```
+
 
 ## What Happens
 

--- a/demo-assets/pyproject.toml
+++ b/demo-assets/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = ""
+version = "0.0.1"
+requires-python = "~=3.12"
+dependencies = [
+    "pyyaml>=6.0.2",
+    "requests",
+]
+
+[dependency-groups]
+dev = []
+
+[tool.uv]
+package = false
+
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"

--- a/demo-assets/resources/BalanceReaderControllerTest.java
+++ b/demo-assets/resources/BalanceReaderControllerTest.java
@@ -232,7 +232,7 @@ class BalanceReaderControllerTest {
         String secondId = System.getProperty("CIRCLE_WORKFLOW_WORKSPACE_ID", "B") ;
         // if running on CI
         if(System.getenv().containsKey("CIRCLE_WORKFLOW_ID")){
-            // upcate live values (will only match first runs!)
+            // update live values (will only match first runs!)
             firstId = System.getenv("CIRCLE_WORKFLOW_ID");
             secondId = System.getenv("CIRCLE_WORKFLOW_WORKSPACE_ID") ;
         }

--- a/demo-assets/runDemo.py
+++ b/demo-assets/runDemo.py
@@ -31,13 +31,13 @@ def main():
     logger.info('\nReady on My Demo Branch %s!!\n',happy_branch)
    
     #Add config violation & pause
-    input(">>> Hit enter to push policy failure")
+    input(">>> Hit enter to push Bad Context Access (prod context on feature build)")
     configHelper.load_config('.circleci/config.yml')
     commit_policy_failure()
     push_changes(happy_branch)
    
     #Add Config violation fix, spawn passing branch with dev deploy
-    input(">>> Hit enter to FIX policy failure, and spawn test failures and pass")
+    input(">>> Hit enter to FIX Context Access, and spawn test failures and pass")
     remove_policy_failure()
     push_changes(happy_branch)
 

--- a/demo-assets/user_info.py
+++ b/demo-assets/user_info.py
@@ -9,7 +9,7 @@ class UserInfo:
 
     fields = {
          "orgname":{"default":"AwesomeCICD","envvar":"GITHUB_ORG"},
-         "reponame":{"default":"Bank-of-aion","envvar":"GITHUB_REPO"},
+         "reponame":{"default":"circle-banking-app","envvar":"GITHUB_REPO"},
          "username":{"default":"","envvar":"GITHUB_USER"},
          "github_token":{"default":"","envvar":"GITHUB_API_TOKEN"},
     }

--- a/demo-assets/uv.lock
+++ b/demo-assets/uv.lock
@@ -1,0 +1,98 @@
+version = 1
+revision = 2
+requires-python = ">=3.12, <4"
+
+[[package]]
+name = ""
+version = "0.0.1"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "requests" },
+]
+
+[package.metadata.requires-dev]
+dev = []
+
+[[package]]
+name = "certifi"
+version = "2022.12.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/f7/2b1b0ec44fdc30a3d31dfebe52226be9ddc40cd6c0f34ffc8923ba423b69/certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3", size = 156897, upload_time = "2022-12-07T20:13:22.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18", size = 155255, upload_time = "2022-12-07T20:13:19.428Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/d7/8d757f8bd45be079d76309248845a04f09619a7b17d6dfc8c9ff6433cac2/charset-normalizer-3.1.0.tar.gz", hash = "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5", size = 95987, upload_time = "2023-03-06T09:49:37.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/81/14b3b8f01ddaddad6cdec97f2f599aa2fa466bd5ee9af99b08b7713ccd29/charset_normalizer-3.1.0-py3-none-any.whl", hash = "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d", size = 46166, upload_time = "2023-03-06T09:49:36.848Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4", size = 183077, upload_time = "2022-09-14T00:24:27.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2", size = 61538, upload_time = "2022-09-14T00:24:23.22Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload_time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload_time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload_time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload_time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload_time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload_time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload_time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload_time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload_time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload_time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload_time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload_time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload_time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload_time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload_time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload_time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload_time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload_time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload_time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.28.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz", hash = "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf", size = 108206, upload_time = "2023-01-12T16:24:54.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa", size = 62822, upload_time = "2023-01-12T16:24:52.241Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "1.26.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/79/6372d8c0d0641b4072889f3ff84f279b738cd8595b64c8e0496d4e848122/urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305", size = 301444, upload_time = "2023-03-11T00:01:41.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f5/890a0baca17a61c1f92f72b81d3c31523c99bec609e60c292ea55b387ae8/urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42", size = 140881, upload_time = "2023-03-11T00:01:39.031Z" },
+]

--- a/src/balancereader/compass.json
+++ b/src/balancereader/compass.json
@@ -1,0 +1,20 @@
+{
+    "component": {
+        "id":"ari:cloud:compass:f70fc615-659b-4377-82ad-9468d843b4b5:component/c3368863-b2d9-4e16-88b6-4aa6087cc55c/92c372c6-4f3f-4d5c-a7c7-a7210f08cec9"
+    },
+    "deployment":{
+        "environment": {
+            "category": "Staging",
+            "displayName": "Demo Environment",
+            "id": "dev-123"
+        },
+        "state": "successful",
+        "eventName": "CBA Test Webhook",
+        "description": "Testing new webooks",
+        "eventUrl": "https://app.circleci.com/pipelines/github/AwesomeCICD/circle-banking-app/1674/workflows/jobs/9291"
+    },
+    "pipeline":{
+        "id": "1234-test",
+        "displayName": "CBA Main Pipeline"
+    }
+}

--- a/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/BalanceCache.java
+++ b/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/BalanceCache.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.balancereader;
+package com.circleci.samples.bankcorp.balancereader;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/BalanceReaderApplication.java
+++ b/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/BalanceReaderApplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.balancereader;
+package com.circleci.samples.bankcorp.balancereader;
 
 import javax.annotation.PreDestroy;
 import org.apache.logging.log4j.Level;

--- a/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/BalanceReaderController.java
+++ b/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/BalanceReaderController.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.balancereader;
+package com.circleci.samples.bankcorp.balancereader;
 
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.exceptions.JWTVerificationException;

--- a/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/JWTVerifierGenerator.java
+++ b/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/JWTVerifierGenerator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.balancereader;
+package com.circleci.samples.bankcorp.balancereader;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;

--- a/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/LedgerReader.java
+++ b/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/LedgerReader.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.balancereader;
+package com.circleci.samples.bankcorp.balancereader;
 
 
 import org.apache.logging.log4j.LogManager;

--- a/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/Transaction.java
+++ b/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/Transaction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.balancereader;
+package com.circleci.samples.bankcorp.balancereader;
 
 import java.util.Date;
 

--- a/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/TransactionRepository.java
+++ b/src/balancereader/src/main/java/com/circleci/samples/bankcorp/balancereader/TransactionRepository.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package anthos.samples.bankofanthos.balancereader;
+package com.circleci.samples.bankcorp.balancereader;
 
 import java.util.List;
 

--- a/src/balancereader/src/test/java/com/circleci/samples/bankcorp/balancereader/BalanceReaderControllerTest.java
+++ b/src/balancereader/src/test/java/com/circleci/samples/bankcorp/balancereader/BalanceReaderControllerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.balancereader;
+package com.circleci.samples.bankcorp.balancereader;
 
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.CacheStats;

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/AccountInfo.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/AccountInfo.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 import java.util.Deque;
 

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/ExceptionMessages.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/ExceptionMessages.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 /**
  * Class for all exception messages used in ledgermonolith.

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/JWTVerifierGenerator.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/JWTVerifierGenerator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/LedgerMonolithApplication.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/LedgerMonolithApplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/LedgerMonolithController.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/LedgerMonolithController.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
-import static anthos.samples.bankofanthos.ledgermonolith.ExceptionMessages.EXCEPTION_MESSAGE_DUPLICATE_TRANSACTION;
-import static anthos.samples.bankofanthos.ledgermonolith.ExceptionMessages.EXCEPTION_MESSAGE_INSUFFICIENT_BALANCE;
-import static anthos.samples.bankofanthos.ledgermonolith.ExceptionMessages.EXCEPTION_MESSAGE_WHEN_AUTHORIZATION_HEADER_NULL;
+import static com.circleci.samples.bankcorp.ledgermonolith.ExceptionMessages.EXCEPTION_MESSAGE_DUPLICATE_TRANSACTION;
+import static com.circleci.samples.bankcorp.ledgermonolith.ExceptionMessages.EXCEPTION_MESSAGE_INSUFFICIENT_BALANCE;
+import static com.circleci.samples.bankcorp.ledgermonolith.ExceptionMessages.EXCEPTION_MESSAGE_WHEN_AUTHORIZATION_HEADER_NULL;
 
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.exceptions.JWTVerificationException;

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/LedgerReader.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/LedgerReader.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 
 import org.apache.logging.log4j.LogManager;

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/LedgerReaderCache.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/LedgerReaderCache.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/Transaction.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/Transaction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 import java.util.Date;
 

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/TransactionRepository.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/TransactionRepository.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/TransactionValidator.java
+++ b/src/ledgermonolith/src/main/java/com/circleci/samples/bankcorp/ledgermonolith/TransactionValidator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgermonolith;
+package com.circleci.samples.bankcorp.ledgermonolith;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,13 +22,13 @@ import org.springframework.stereotype.Component;
 
 import java.util.regex.Pattern;
 
-import static anthos.samples.bankofanthos.ledgermonolith.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgermonolith.ExceptionMessages.
         EXCEPTION_MESSAGE_INVALID_NUMBER;
-import static anthos.samples.bankofanthos.ledgermonolith.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgermonolith.ExceptionMessages.
         EXCEPTION_MESSAGE_NOT_AUTHENTICATED;
-import static anthos.samples.bankofanthos.ledgermonolith.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgermonolith.ExceptionMessages.
         EXCEPTION_MESSAGE_SEND_TO_SELF;
-import static anthos.samples.bankofanthos.ledgermonolith.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgermonolith.ExceptionMessages.
         EXCEPTION_MESSAGE_INVALID_AMOUNT;
 
 

--- a/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/ExceptionMessages.java
+++ b/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/ExceptionMessages.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
 /**
  * Class for all exception messages used in ledgerwriter.

--- a/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/JWTVerifierGenerator.java
+++ b/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/JWTVerifierGenerator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;

--- a/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/LedgerWriterApplication.java
+++ b/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/LedgerWriterApplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
 import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;

--- a/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/LedgerWriterController.java
+++ b/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/LedgerWriterController.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_DUPLICATE_TRANSACTION;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_INSUFFICIENT_BALANCE;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_WHEN_AUTHORIZATION_HEADER_NULL;
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_DUPLICATE_TRANSACTION;
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_INSUFFICIENT_BALANCE;
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_WHEN_AUTHORIZATION_HEADER_NULL;
 
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.exceptions.JWTVerificationException;

--- a/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/Transaction.java
+++ b/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/Transaction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
 import java.util.Date;
 

--- a/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/TransactionRepository.java
+++ b/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/TransactionRepository.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;

--- a/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/TransactionValidator.java
+++ b/src/ledgerwriter/src/main/java/com/circleci/samples/bankcorp/ledgerwriter/TransactionValidator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,13 +22,13 @@ import org.springframework.stereotype.Component;
 
 import java.util.regex.Pattern;
 
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.
         EXCEPTION_MESSAGE_INVALID_NUMBER;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.
         EXCEPTION_MESSAGE_NOT_AUTHENTICATED;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.
         EXCEPTION_MESSAGE_SEND_TO_SELF;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.
         EXCEPTION_MESSAGE_INVALID_AMOUNT;
 
 

--- a/src/ledgerwriter/src/test/java/com/circleci/samples/bankcorp/ledgerwriter/LedgerWriterControllerTest.java
+++ b/src/ledgerwriter/src/test/java/com/circleci/samples/bankcorp/ledgerwriter/LedgerWriterControllerTest.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_DUPLICATE_TRANSACTION;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_INSUFFICIENT_BALANCE;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_WHEN_AUTHORIZATION_HEADER_NULL;
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_DUPLICATE_TRANSACTION;
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_INSUFFICIENT_BALANCE;
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.EXCEPTION_MESSAGE_WHEN_AUTHORIZATION_HEADER_NULL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.doReturn;

--- a/src/ledgerwriter/src/test/java/com/circleci/samples/bankcorp/ledgerwriter/TransactionValidatorTest.java
+++ b/src/ledgerwriter/src/test/java/com/circleci/samples/bankcorp/ledgerwriter/TransactionValidatorTest.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.ledgerwriter;
+package com.circleci.samples.bankcorp.ledgerwriter;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.
         EXCEPTION_MESSAGE_INVALID_NUMBER;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.
         EXCEPTION_MESSAGE_NOT_AUTHENTICATED;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.
         EXCEPTION_MESSAGE_SEND_TO_SELF;
-import static anthos.samples.bankofanthos.ledgerwriter.ExceptionMessages.
+import static com.circleci.samples.bankcorp.ledgerwriter.ExceptionMessages.
         EXCEPTION_MESSAGE_INVALID_AMOUNT;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;

--- a/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/JWTVerifierGenerator.java
+++ b/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/JWTVerifierGenerator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.transactionhistory;
+package com.circleci.samples.bankcorp.transactionhistory;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;

--- a/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/LedgerReader.java
+++ b/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/LedgerReader.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.transactionhistory;
+package com.circleci.samples.bankcorp.transactionhistory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/Transaction.java
+++ b/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/Transaction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.transactionhistory;
+package com.circleci.samples.bankcorp.transactionhistory;
 
 import java.util.Date;
 

--- a/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/TransactionCache.java
+++ b/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/TransactionCache.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.transactionhistory;
+package com.circleci.samples.bankcorp.transactionhistory;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;

--- a/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/TransactionHistoryApplication.java
+++ b/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/TransactionHistoryApplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.transactionhistory;
+package com.circleci.samples.bankcorp.transactionhistory;
 
 import javax.annotation.PreDestroy;
 import org.apache.logging.log4j.Level;

--- a/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/TransactionHistoryController.java
+++ b/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/TransactionHistoryController.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.transactionhistory;
+package com.circleci.samples.bankcorp.transactionhistory;
 
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.exceptions.JWTVerificationException;

--- a/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/TransactionRepository.java
+++ b/src/transactionhistory/src/main/java/com/circleci/samples/bankcorp/transactionhistory/TransactionRepository.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package anthos.samples.bankofanthos.transactionhistory;
+package com.circleci.samples.bankcorp.transactionhistory;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/transactionhistory/src/test/java/com/circleci/samples/bankcorp/transactionhistory/TransactionHistoryControllerTest.java
+++ b/src/transactionhistory/src/test/java/com/circleci/samples/bankcorp/transactionhistory/TransactionHistoryControllerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package anthos.samples.bankofanthos.transactionhistory;
+package com.circleci.samples.bankcorp.transactionhistory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
When asked for a flaky test today I discovered we have not been using the demo script for CBA, which creates a flaky test.

This PR removes some policy stuff and fixes repo name to match current.  It also completes a partial class renaming away from BOA.