### PR TITLE
Revert Commit 1f6da58 so pipelines on main can run without config.yml validation errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   with-chrome:
     docker:
-      - image: 'cypress/browsers:node-20.11.1-chrome-124.0.6367.91-1-ff-135.0-edge-124.0.2478.51-1'
+      - image: 'cypress/browsers:node-20.11.1-chrome-123.0.6312.58-1-ff-124.0-edge-122.0.2365.92-1'
 
   base:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   with-chrome:
     docker:
-      - image: 'cypress/browsers:node-20.11.1-chrome-123.0.6312.58-1-ff-124.0-edge-122.0.2365.92-1'
+      - image: 'cypress/browsers:node-22.14.0-chrome-133.0.6943.126-1-ff-135.0.1-edge-133.0.3065.82-1'
 
   base:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   with-chrome:
     docker:
-      - image: 'cypress/browsers:node-20.6.1-chrome-116.0.5845.187-1-ff-117.0-edge-116.0.1938.76-1'
+      - image: 'cypress/browsers:node-20.11.1-chrome-124.0.6367.91-1-ff-135.0-edge-124.0.2478.51-1'
 
   base:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,66 +280,8 @@ jobs:
       - store_artifacts:
           path: ui-tests/cypress/videos
       - store_artifacts:
-          path: ui-tests/cypress/screenshots    
-<<<<<<< HEAD
-=======
-   
-workflows:
-  main:
-    jobs:
-      - java-checkstyle:
-          context: [ compass-integration-bank-of-aion ]
-      - java-test-and-code-cov
-      - python-checkstyle
-      - python-test
-      - python-test-parallel
-      - skaffold-build-push:
-          matrix:
-            parameters:
-              region: [emea, namer]
-          context: cera-vault-oidc
-          region: <<matrix.region>>
-          name: Skaffold build & Push [<<matrix.region>>]
-      - deploy:
-          matrix:
-            parameters:
-              region: [emea,namer]
-          name: Deploy Dev [<<matrix.region>>]
-          region: <<matrix.region>>
-          requires: [ 'Skaffold build & Push [<<matrix.region>>]', python-test, java-test-and-code-cov ]
-          context: [ compass-integration-bank-of-aion, cera-vault-oidc]
-          post-steps:
-            - compass/notify_deployment:
-                token_name: COMPASS_CCI_TOKEN
-                environment_type: development
-      - e2e:
-          matrix:
-            parameters:
-              region: [emea,namer]
-          name: e2e [<<matrix.region>>]
-          requires: [ 'Deploy Dev [<<matrix.region>>]' ]
-          region: <<matrix.region>>
-      - deploy:
-          matrix:
-            parameters:
-              region: [emea,namer]
-          name: Deploy Production [<<matrix.region>>]
-          requires: 
-            - 'e2e [<<matrix.region>>]'
-          app-environment: prod
-          region: <<matrix.region>>
-          context: [ compass-integration-bank-of-aion, cera-vault-oidc-prod ]
-          filters:
-            branches:
-              only: [ main ]
-          post-steps:
-            - compass/notify_deployment:
-                token_name: COMPASS_CCI_TOKEN
-                environment_type: production
-                environment: CERA-Cluster-namer-Prod
-
->>>>>>> a043408 (Breaking policy)
-
+          path: ui-tests/cypress/screenshots
+          
 commands:
   load-credentials:
     parameters:


### PR DESCRIPTION
## Summary
This PR reverts commit [`1f6da58`](https://github.com/AwesomeCICD/circle-banking-app/commit/1f6da58307895d36d8628175bbe2fe08fff19f6d) to undo the changes it introduced.

## Reason for Revert
Pipelines are failing due to validation errors in `.circleci/config.yml` (example: [pipeline #1820](https://app.circleci.com/pipelines/github/AwesomeCICD/circle-banking-app/1820)).

**Why?**  
This allows pipelines to be run on `main` without validation errors for demo purposes.

## Tests
[Pipelines #1822](https://app.circleci.com/pipelines/github/AwesomeCICD/circle-banking-app/1822/workflows/eac9bbf8-38f2-4005-bd92-a9b2dc88ff22) seems to work without validation errors.